### PR TITLE
add ralloc from mesa as a talloc replacement

### DIFF
--- a/libs/ralloc/Makefile
+++ b/libs/ralloc/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2011-2012 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ralloc
+PKG_VERSION:=10.3.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=MesaLib-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=ftp://ftp.freedesktop.org/pub/mesa/10.3/
+PKG_BUILD_DIR:=$(BUILD_DIR)/Mesa-$(PKG_VERSION)
+PKG_MD5SUM:=bc071575596a074df2b15cac57c01ed8
+
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libralloc
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=MIT-x licenced talloc replacement
+endef
+
+define Package/libralloc/description
+endef
+
+define Build/Configure
+	/bin/true
+endef
+
+define Build/Compile
+	$(TARGET_CC) $(TARGET_CFLAGS) -Wall -shared \
+		-o $(PKG_BUILD_DIR)/libralloc.so $(PKG_BUILD_DIR)/src/util/ralloc.c
+endef
+
+define Package/libralloc/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/libralloc.so $(1)/usr/lib/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/src/util/ralloc.h $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/libralloc.so $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libralloc))

--- a/libs/ralloc/patches/0001-ralloc-allow-ctx-to-be-NULL-for-reralloc.patch
+++ b/libs/ralloc/patches/0001-ralloc-allow-ctx-to-be-NULL-for-reralloc.patch
@@ -1,0 +1,27 @@
+From f6e0deb59a625e8e4ad0cd2c81fa8913fe15e588 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jogo@openwrt.org>
+Date: Wed, 24 Sep 2014 16:11:12 +0200
+Subject: [PATCH 1/3] ralloc: allow ctx to be NULL for reralloc
+
+---
+ src/util/ralloc.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/util/ralloc.c b/src/util/ralloc.c
+index 36bc61f..aabe312 100644
+--- a/src/util/ralloc.c
++++ b/src/util/ralloc.c
+@@ -174,7 +174,9 @@ reralloc_size(const void *ctx, void *ptr, size_t size)
+    if (unlikely(ptr == NULL))
+       return ralloc_size(ctx, size);
+ 
+-   assert(ralloc_parent(ptr) == ctx);
++   if (ctx != NULL)
++      assert(ralloc_parent(ptr) == ctx);
++
+    return resize(ptr, size);
+ }
+ 
+-- 
+2.0.1
+

--- a/libs/ralloc/patches/0002-ralloc-replace-macros.h-include-with-required-macro.patch
+++ b/libs/ralloc/patches/0002-ralloc-replace-macros.h-include-with-required-macro.patch
@@ -1,0 +1,40 @@
+From 1818c7aefb73bc51e1f2dd7c5c17ce490817ccc1 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jogo@openwrt.org>
+Date: Wed, 24 Sep 2014 16:17:00 +0200
+Subject: [PATCH 2/3] ralloc: replace macros.h include with required macro
+
+Allow it to be exported.
+---
+ src/util/ralloc.h | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/util/ralloc.h b/src/util/ralloc.h
+index 4b88f32..279213d 100644
+--- a/src/util/ralloc.h
++++ b/src/util/ralloc.h
+@@ -54,7 +54,21 @@ extern "C" {
+ #include <stdarg.h>
+ #include <stdbool.h>
+ 
+-#include "macros.h"
++#if (__GNUC__ >= 3)
++#define PRINTFLIKE(f, a) __attribute__ ((format(__printf__, f, a)))
++#else
++#define PRINTFLIKE(f, a)
++#endif
++
++#ifndef likely
++#  ifdef __GNUC__
++#    define likely(x)   __builtin_expect(!!(x), 1)
++#    define unlikely(x) __builtin_expect(!!(x), 0)
++#  else
++#    define likely(x)   (x)
++#    define unlikely(x) (x)
++#  endif
++#endif
+ 
+ /**
+  * \def ralloc(ctx, type)
+-- 
+2.0.1
+

--- a/libs/ralloc/patches/0003-ralloc-add-memdup.patch
+++ b/libs/ralloc/patches/0003-ralloc-add-memdup.patch
@@ -1,0 +1,53 @@
+From 786d3b4ac4951516ba10738a1725adb3c840548b Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jogo@openwrt.org>
+Date: Wed, 24 Sep 2014 16:21:38 +0200
+Subject: [PATCH 3/3] ralloc: add memdup
+
+---
+ src/util/ralloc.c | 13 +++++++++++++
+ src/util/ralloc.h |  5 +++++
+ 2 files changed, 18 insertions(+)
+
+diff --git a/src/util/ralloc.c b/src/util/ralloc.c
+index aabe312..d7303a8 100644
+--- a/src/util/ralloc.c
++++ b/src/util/ralloc.c
+@@ -310,6 +310,19 @@ ralloc_set_destructor(const void *ptr, void(*destructor)(void *))
+    info->destructor = destructor;
+ }
+ 
++void *
++ralloc_memdup(const void *ctx, const void *ptr, size_t size)
++{
++   char *mem;
++
++   if (unlikely(ptr == NULL))
++      return NULL;
++
++   mem = ralloc_size(ctx, size);
++   memcpy(mem, ptr, size);
++   return mem;
++}
++
+ char *
+ ralloc_strdup(const void *ctx, const char *str)
+ {
+diff --git a/src/util/ralloc.h b/src/util/ralloc.h
+index 279213d..dea2e2a 100644
+--- a/src/util/ralloc.h
++++ b/src/util/ralloc.h
+@@ -269,6 +269,11 @@ void ralloc_set_destructor(const void *ptr, void(*destructor)(void *));
+ 
+ /// \defgroup array String Functions @{
+ /**
++ * Duplicate memory, allocating the memory from the given context.
++ */
++void *ralloc_memdup(const void *ctx, const void *ptr, size_t size);
++
++/**
+  * Duplicate a string, allocating the memory from the given context.
+  */
+ char *ralloc_strdup(const void *ctx, const char *str);
+-- 
+2.0.1
+


### PR DESCRIPTION
Add a packaged stand-alone version of ralloc from the Mesa project to
be used as an easy replacement for the GPLv3 licensed talloc from the
samba project.

Functionality was supplemented as needed for mand.

Signed-off-by: Jonas Gorski jogo@openwrt.org
